### PR TITLE
Fix version number

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -5,5 +5,5 @@ Redmine::Plugin.register :redmine_ssl_auth_cn do
   name 'Redmine SSL Auth CN plugin'
   author 'Steve Simpson'
   description 'Enable authentication using SSL client certificates where username=[certificate common name].'
-  version '0.1.1'
+  version '1.0.1'
 end


### PR DESCRIPTION
The version number in the code is different from the tag which confused me.
I discovered it with my Redmine instance which shown me that an update was available (0.1.1 -> 1.0.1). This is actually wrong since I'm already using the latest version (1.0.1). I fixed the problem by updating the version number in the init.rb file.